### PR TITLE
Fix price.fixed is not a function error

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -43,7 +43,7 @@ const App = () => {
   }, [selectedCrypto, selectedDays]);
 
   const formatPrice = (price) => {
-    return price.toFixed(2);
+    return Number(price).toFixed(2);
   };
 
   const formatChange = (current, previous) => {


### PR DESCRIPTION
Fix the `price.fixed is not a function` error in `src/App.js` and update `fetchFutureContractPrices` in `src/api/binance.js`.

* Convert `price` to a number before calling `toFixed(2)` in the `formatPrice` function in `src/App.js`.
* Add a new function `getQuarterlyAndBiquarterlyNames` in `src/api/binance.js` to fetch quarterly and biquarterly contract names.
* Update `fetchFutureContractPrices` in `src/api/binance.js` to:
  - Fetch and convert perpetual, quarterly, and biquarterly prices to numbers.
  - Correctly calculate and return the prices for perpetual, quarterly, and biquarterly contracts.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jaume-ferrarons/binance-futures-app/pull/2?shareId=fd049edb-10a0-493f-ad72-522f8b32fc73).