### PR TITLE
Fix frequency dropdown and add spread toggle

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -13,6 +13,7 @@ const App = () => {
   const [selectedDays, setSelectedDays] = useState(7);
   const [selectedFrequency, setSelectedFrequency] = useState('1d');
   const [isLoading, setIsLoading] = useState(false);
+  const [isSpread, setIsSpread] = useState(false);
 
   const handleCryptoChange = (event) => {
     setSelectedCrypto(event.target.value);
@@ -168,7 +169,10 @@ const App = () => {
           <MenuItem value="1d">1d</MenuItem>
         </Select>
       </FormControl>
-      {isLoading ? <LoadingSpinner /> : <Plot historicalPrices={historicalPrices} selectedCrypto={selectedCrypto} />}
+      <Button variant="contained" color="primary" onClick={() => setIsSpread(!isSpread)}>
+        {isSpread ? 'Show Prices' : 'Show Spread %'}
+      </Button>
+      {isLoading ? <LoadingSpinner /> : <Plot historicalPrices={historicalPrices} selectedCrypto={selectedCrypto} isSpread={isSpread} />}
     </Container>
   );
 };

--- a/src/api/binance.js
+++ b/src/api/binance.js
@@ -87,12 +87,24 @@ export const fetchHistoricalPrices = async (crypto, days, frequency) => {
       biquarterly: price[4],
     }));
 
-    const combinedPrices = perpetualPrices.map((perpetualPrice, index) => ({
-      date: perpetualPrice.date,
-      perpetual: perpetualPrice.perpetual,
-      quarterly: quarterlyPrices[index] ? quarterlyPrices[index].quarterly : null,
-      biquarterly: biquarterlyPrices[index] ? biquarterlyPrices[index].biquarterly : null,
-    }));
+    const allDates = Array.from(new Set([
+      ...perpetualPrices.map((price) => price.date),
+      ...quarterlyPrices.map((price) => price.date),
+      ...biquarterlyPrices.map((price) => price.date),
+    ])).sort((a, b) => new Date(a) - new Date(b));
+
+    const combinedPrices = allDates.map((date) => {
+      const perpetualPrice = perpetualPrices.find((price) => price.date === date);
+      const quarterlyPrice = quarterlyPrices.find((price) => price.date === date);
+      const biquarterlyPrice = biquarterlyPrices.find((price) => price.date === date);
+
+      return {
+        date,
+        perpetual: perpetualPrice ? perpetualPrice.perpetual : null,
+        quarterly: quarterlyPrice ? quarterlyPrice.quarterly : null,
+        biquarterly: biquarterlyPrice ? biquarterlyPrice.biquarterly : null,
+      };
+    });
 
     return combinedPrices;
   } catch (error) {

--- a/src/components/Plot.js
+++ b/src/components/Plot.js
@@ -4,29 +4,62 @@ import { Chart as ChartJS, CategoryScale, LinearScale, PointElement, LineElement
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend);
 
-const Plot = ({ historicalPrices, selectedCrypto }) => {
+const Plot = ({ historicalPrices, selectedCrypto, isSpread }) => {
   const data = {
     labels: historicalPrices.map((price) => price.date),
-    datasets: [
-      {
-        label: `${selectedCrypto} Perpetual Prices`,
-        data: historicalPrices.map((price) => price.perpetual),
-        borderColor: 'rgba(75, 192, 192, 1)',
-        backgroundColor: 'rgba(75, 192, 192, 0.2)',
-      },
-      {
-        label: `${selectedCrypto} Quarterly Prices`,
-        data: historicalPrices.map((price) => price.quarterly),
-        borderColor: 'rgba(255, 99, 132, 1)',
-        backgroundColor: 'rgba(255, 99, 132, 0.2)',
-      },
-      {
-        label: `${selectedCrypto} Biquarterly Prices`,
-        data: historicalPrices.map((price) => price.biquarterly),
-        borderColor: 'rgba(54, 162, 235, 1)',
-        backgroundColor: 'rgba(54, 162, 235, 0.2)',
-      },
-    ],
+    datasets: isSpread
+      ? [
+          {
+            label: `${selectedCrypto} Perpetual - Quarterly Spread %`,
+            data: historicalPrices.map((price) =>
+              price.perpetual && price.quarterly
+                ? ((price.perpetual - price.quarterly) / price.perpetual) * 100
+                : null
+            ),
+            borderColor: 'rgba(75, 192, 192, 1)',
+            backgroundColor: 'rgba(75, 192, 192, 0.2)',
+          },
+          {
+            label: `${selectedCrypto} Perpetual - Biquarterly Spread %`,
+            data: historicalPrices.map((price) =>
+              price.perpetual && price.biquarterly
+                ? ((price.perpetual - price.biquarterly) / price.perpetual) * 100
+                : null
+            ),
+            borderColor: 'rgba(255, 99, 132, 1)',
+            backgroundColor: 'rgba(255, 99, 132, 0.2)',
+          },
+          {
+            label: `${selectedCrypto} Quarterly - Biquarterly Spread %`,
+            data: historicalPrices.map((price) =>
+              price.quarterly && price.biquarterly
+                ? ((price.quarterly - price.biquarterly) / price.quarterly) * 100
+                : null
+            ),
+            borderColor: 'rgba(54, 162, 235, 1)',
+            backgroundColor: 'rgba(54, 162, 235, 0.2)',
+          },
+        ]
+      : [
+          {
+            label: `${selectedCrypto} Perpetual Prices`,
+            data: historicalPrices.map((price) => price.perpetual),
+            borderColor: 'rgba(75, 192, 192, 1)',
+            backgroundColor: 'rgba(75, 192, 192, 0.2)',
+          },
+          {
+            label: `${selectedCrypto} Quarterly Prices`,
+            data: historicalPrices.map((price) => price.quarterly),
+            borderColor: 'rgba(255, 99, 132, 1)',
+            backgroundColor: 'rgba(255, 99, 132, 0.2)',
+          },
+          {
+            label: `${selectedCrypto} Biquarterly Prices`,
+            data: historicalPrices.map((price) => price.biquarterly),
+            borderColor: 'rgba(54, 162, 235, 1)',
+            backgroundColor: 'rgba(54, 162, 235, 0.2)',
+          },
+        ],
   };
 
   const options = {
@@ -37,13 +70,13 @@ const Plot = ({ historicalPrices, selectedCrypto }) => {
       },
       title: {
         display: true,
-        text: `${selectedCrypto} Prices Over Time`,
+        text: `${selectedCrypto} ${isSpread ? 'Spread %' : 'Prices'} Over Time`,
       },
       tooltip: {
         callbacks: {
           label: function (context) {
             const label = context.dataset.label || '';
-            const value = context.raw || '';
+            const value = context.raw !== null ? Number(context.raw).toFixed(2) : ''; // P67e8
             const date = context.label || '';
             return `${label}: ${value} (Date: ${date})`;
           },


### PR DESCRIPTION
Add functionality to align plot data by date and toggle between price and spread %.

* **src/api/binance.js**
  - Modify the `combinedPrices` logic to align data by date from all price series.

* **src/components/Plot.js**
  - Update the `Plot` component to accept the `isSpread` prop.
  - Modify the `data` object to plot spread % instead of prices when `isSpread` is true.
  - Update the spread legend to display 2 decimal positions.
  - Fix the `toFixed` error in the `Tooltip.label` callback by ensuring the value is a number.

* **src/App.js**
  - Add a new state variable `isSpread` to manage the toggle state.
  - Add a toggle button to switch between price and spread % in the JSX.
  - Pass the `isSpread` state as a prop to the `Plot` component.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jaume-ferrarons/binance-futures-app/pull/6?shareId=538c8da4-14df-490f-8bab-8de707109734).