### PR TITLE
Fix frequency dropdown to display date and time

### DIFF
--- a/src/api/binance.js
+++ b/src/api/binance.js
@@ -61,7 +61,7 @@ export const fetchHistoricalPrices = async (crypto, days, frequency) => {
       `${BINANCE_API_URL}/klines?symbol=${crypto}USDT&interval=${interval}&startTime=${startTime}&endTime=${endTime}`
     );
     const perpetualPrices = perpetualResponse.data.map((price) => ({
-      date: new Date(price[0]).toLocaleDateString(),
+      date: new Date(price[0]).toLocaleString(),
       perpetual: price[4],
     }));
 
@@ -73,7 +73,7 @@ export const fetchHistoricalPrices = async (crypto, days, frequency) => {
         )
       : { data: [] };
     const quarterlyPrices = quarterlyResponse.data.map((price) => ({
-      date: new Date(price[0]).toLocaleDateString(),
+      date: new Date(price[0]).toLocaleString(),
       quarterly: price[4],
     }));
 
@@ -83,7 +83,7 @@ export const fetchHistoricalPrices = async (crypto, days, frequency) => {
         )
       : { data: [] };
     const biquarterlyPrices = biquarterlyResponse.data.map((price) => ({
-      date: new Date(price[0]).toLocaleDateString(),
+      date: new Date(price[0]).toLocaleString(),
       biquarterly: price[4],
     }));
 

--- a/src/components/Dropdown.js
+++ b/src/components/Dropdown.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import { FormControl, InputLabel, Select, MenuItem } from '@material-ui/core';
 
-const Dropdown = ({ options, selectedValue, onChange }) => {
+const Dropdown = ({ options, selectedValue, onChange, label }) => {
   return (
     <FormControl className="dropdown">
-      <InputLabel>Options</InputLabel>
+      <InputLabel>{label}</InputLabel>
       <Select value={selectedValue} onChange={onChange}>
         {options.map((option) => (
           <MenuItem key={option} value={option}>


### PR DESCRIPTION
Update the frequency dropdown to display the correct date and time format.

* **src/api/binance.js**
  - Update `fetchHistoricalPrices` function to use `toLocaleString` instead of `toLocaleDateString` for the `date` field.

* **src/components/Dropdown.js**
  - Update `Dropdown` component to accept a `label` prop and use it for the `InputLabel`.

