### PR TITLE
Fix GitHub Pages deployment error

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build"
   },
-  "homepage": "https://<username>.github.io/<repository-name>",
+  "homepage": "https://jaume-ferrarons.github.io/binance-futures-app",
   "dependencies": {
     "@material-ui/core": "^4.12.4",
     "@material-ui/icons": "^4.11.3",

--- a/public/index.html
+++ b/public/index.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Binance Futures Price Comparison</title>
     <meta name="description" content="A web app to compare Binance futures prices and compute spreads" />
-    <link rel="stylesheet" href="/styles.css" />
-    <link rel="stylesheet" href="/src/styles.css" />
+    <link rel="stylesheet" href="./styles.css" />
+    <link rel="stylesheet" href="./src/styles.css" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css" />
   </head>


### PR DESCRIPTION
Fix the script source loading error when deploying to GitHub Pages.

* **package.json**
  - Update the `homepage` field to `https://jaume-ferrarons.github.io/binance-futures-app`.

* **public/index.html**
  - Update the `<link>` tags for `styles.css` and `src/styles.css` to use relative paths.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jaume-ferrarons/binance-futures-app/pull/11?shareId=0cd21136-3c0a-4157-801f-ece6bb1cab11).